### PR TITLE
Fix pam_pkcs11.xsl

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,7 +25,7 @@ STYLESHEET = pam_pkcs11.xsl
 
 %.html: %.xml $(STYLESHEET)
 if HAVE_DOCBOOK
-	$(XSLTPROC) --path /usr/share/sgml/docbook/xsl-stylesheets/xhtml:/usr/share/xml/docbook/stylesheet/nwalsh/xhtml \
+	$(XSLTPROC) \
 	--stringparam  section.autolabel 1 \
 	--stringparam  section.label.includes.component.label 1 \
 	-o $@ $(STYLESHEET) $<

--- a/doc/pam_pkcs11.xsl
+++ b/doc/pam_pkcs11.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
-	<xsl:import href="docbook.xsl"/>
+	<xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
 
 	<xsl:param name="html.stylesheet" select="'pam_pkcs11.css'"/>
 	<xsl:param name="html.cleanup" select="1" />


### PR DESCRIPTION
Let /etc/xml/catalog resolve docbook.xsl instead of
using a hardcoded path.
