### PR TITLE
Fix translation of line 208 "Smartcard authentication starts"

### DIFF
--- a/src/pam_pkcs11/pam_pkcs11.c
+++ b/src/pam_pkcs11/pam_pkcs11.c
@@ -199,6 +199,12 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
   char **issuer, **serial;
   const char *login_token_name = NULL;
 
+#ifdef ENABLE_NLS
+  setlocale(LC_ALL, "");
+  bindtextdomain(PACKAGE, "/usr/share/locale");
+  textdomain(PACKAGE);
+#endif
+
   pam_prompt(pamh, PAM_TEXT_INFO , NULL, _("Smartcard authentication starts"));
 
   /* first of all check whether debugging should be enabled */
@@ -237,12 +243,6 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 		  }
 	  }
   }
-
-#ifdef ENABLE_NLS
-  setlocale(LC_ALL, "");
-  bindtextdomain(PACKAGE, "/usr/share/locale");
-  textdomain(PACKAGE);
-#endif
 
   /* init openssl */
   rv = crypto_init(&configuration->policy);


### PR DESCRIPTION
Line 208 dont get i18n because the configs are after the line. I move the configs to before to make translation work.