### PR TITLE
Do not fail if card was already unlocked, e.g. by a previous PAM module

### DIFF
--- a/src/common/pkcs11_lib.c
+++ b/src/common/pkcs11_lib.c
@@ -1385,7 +1385,7 @@ int pkcs11_login(pkcs11_handle_t *h, char *password)
 	  rv = h->fl->C_Login(h->session, CKU_USER, (unsigned char*)password, strlen(password));
   else
 	  rv = h->fl->C_Login(h->session, CKU_USER, NULL, 0);
-  if (rv != CKR_OK) {
+  if ((rv != CKR_OK) && (rv != CKR_USER_ALREADY_LOGGED_IN)) {
     set_error("C_Login() failed: 0x%08lX", rv);
     return -1;
   }


### PR DESCRIPTION
This fixes a failure to log in when pam_pkcs11 is chained after pam_krb5 (i.e. used as a backup authentication mechanism if the Kerberos KDC is unavailable).