### PR TITLE
- Solaris runs build process outside of srcdir

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -21,7 +21,7 @@ EXTRA_DIST = $(MANSRC) $(XMLFILES) $(HTMLFILES) doxygen.conf.in \
 	README.ldap_mapper export-wiki.sh generate-api.sh \
 	api/index.html $(shell ls api/*)
 
-STYLESHEET = pam_pkcs11.xsl
+STYLESHEET = $(srcdir)/pam_pkcs11.xsl
 
 %.html: %.xml $(STYLESHEET)
 if HAVE_DOCBOOK


### PR DESCRIPTION
this small tweak makes our life easier and should not harm other
pam_pkcs11 users.

Our build process generates makefiles and objects in dedicated
build directory. without this patch it fails with error as follows:

xsltproc \
--stringparam  section.autolabel 1 \
--stringparam  section.label.includes.component.label 1 \
-o pam_pkcs11.html pam_pkcs11.xsl /scratch/sashan/userland/components/pam_pkcs11/pam_pkcs11-0.6.10/doc/pam_pkcs11.xml
warning: failed to load external entity "pam_pkcs11.xsl"
cannot parse pam_pkcs11.xsl
make[3]: *** [Makefile:644: pam_pkcs11.html] Error 4
make[3]: Leaving directory '/scratch/sashan/userland/components/pam_pkcs11/build/i86/doc'
make[2]: *** [Makefile:464: all-recursive] Error 1
make[2]: Leaving directory '/scratch/sashan/userland/components/pam_pkcs11/build/i86'
make[1]: *** [Makefile:396: all] Error 2

change in this pull request makes my build happy.