### PR TITLE
pam_config: Handle 'card_only' option from command line

### DIFF
--- a/src/pam_pkcs11/pam_config.c
+++ b/src/pam_pkcs11/pam_config.c
@@ -266,6 +266,10 @@ struct configuration_st *pk_configure( int argc, const char **argv ) {
       		configuration.use_first_pass = 1;
 		continue;
 	   }
+    	   if (strcmp("card_only", argv[i]) == 0) {
+      		configuration.card_only = 1;
+		continue;
+	   }
     	   if (strcmp("wait_for_card", argv[i]) == 0) {
       		configuration.wait_for_card = 1;
 		continue;


### PR DESCRIPTION
Without this change `card_only` is not supported when specified from the command line.