### PR TITLE
Codespell

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,18 @@
+---
+name: Codespell
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: codespell-project/actions-codespell@master
+        with:
+          skip: *.po,base64.*,SSLerrs.h
+          ignore_words_file: codespell_ignore_words.txt

--- a/AUTHORS
+++ b/AUTHORS
@@ -11,7 +11,7 @@ Timo Sirainen <tss@iki.fi>
 
 Ludovic Rousseau <ludovic.rousseau@free.fr>
 	Many fixes and improvements
-	card_eventmgr mantainer
+	card_eventmgr maintainer
 
 Andreas Jellinghaus <aj@dungeon.inka.de>
 	OpenSC and OpenSSH mappers original

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,7 +8,7 @@
       error when the authentication isn't restricted to card only
       (either by the option `card_only` or by PKCS11_LOGIN_TOKEN_NAME
       environment variable).
-    - Added the exmple PAM configuration which uses the ignore status
+    - Added the example PAM configuration which uses the ignore status
       result.
     - Added `screen_savers` to example config.
     - Fixes to deal with old and new OpenSSL versions.
@@ -52,7 +52,7 @@
 01- Sep 2005
 	- Finished OpenSC mapper. Thanks to Andreas for their pam_opensc module
 	- New .spec file
-	- Cleanning tasks to prepare next release
+	- Cleaning tasks to prepare next release
 
 31- Aug 2005
 	- Include HOWTO in Pam-pkcs11 manual
@@ -123,12 +123,12 @@
 
 31- Mar 2005
 	- Added CA & CRL mgmnt doc to manual
-	- Chaged  ocurrences of "if (!x) free(x)" to "free(x)" as glibc 
-	  already does propper null check
+	- Changed  occurrences of "if (!x) free(x)" to "free(x)" as glibc 
+	  already does proper null check
 	- Finished krb_mapper ( no pkinit, just kpn -> login map ).
 	  NOTE: I assume that KPN is stored as ASN1_STRING, but cannot
 	  deduce it from RFC's
-	- MS mapper rewriten to use cert_info lib
+	- MS mapper rewritten to use cert_info lib
 
 29- Mar 2005
 	- Manual rewritten in xml format
@@ -176,7 +176,7 @@
 
 4- Mar 2005
 	- Added mapfiles to UID mapper
-	- ms_mapper now works properly ( sorry, no ADS conection yet :-( )
+	- ms_mapper now works properly ( sorry, no ADS connection yet :-( )
 	- Updated doc and sample files
 
 3- Mar 2005

--- a/README
+++ b/README
@@ -21,7 +21,7 @@ Standard (PKCS #11) is available at [4].
 
 PKCS #11 Module Requirements
 ----------------------------------------------------------------------
-The PKCS #11 modules must fullfill the requirements given by the RSA
+The PKCS #11 modules must fulfill the requirements given by the RSA
 Asymmetric Client Signing Profile, which has been specified in the
 PKCS #11 Conformance Profile Specification [5] by RSA Laboratories.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Laboratories.
 To map the ownership of a certificate into a user login, pam-pkcs11 uses
 the concept of *mapper* that is, a list of configurable, stackable
 list of dynamic modules, each one trying to do a specific cert-to-login
-maping. Several mappers are provided:
+mapping. Several mappers are provided:
 
 * the common name of the subject matches the login name
 * the unique identifier of the subject matches the login name

--- a/codespell_ignore_words.txt
+++ b/codespell_ignore_words.txt
@@ -1,0 +1,5 @@
+ba
+gord
+parm
+parms
+pres

--- a/doc/README.autologin
+++ b/doc/README.autologin
@@ -60,7 +60,7 @@ provided for logging processes running as root.
 
 Improper mapper chain configurations with unauthorized certificates can
 lead in the creation of fake accounts in the system if pam_mkhomedir.so
-module is used. So be really carefull when authenticating users directly
+module is used. So be really careful when authenticating users directly
 from certificates.
 
 Enjoy!

--- a/doc/README.eventmgr
+++ b/doc/README.eventmgr
@@ -15,14 +15,14 @@ To invoke the program, just type "card_eventmgr".
 Several command lines are recognized:
 
 - debug   - to enable debugging. Defaults to unset
-- daemon  - to run as daemon. If debug is unset, also dettach from tty.
+- daemon  - to run as daemon. If debug is unset, also detach from tty.
             Default to unset
 - timeout=<msecs>    - time in msec between two consecutive status poll.
                        Defaults to 1000 (1 second)
 - config_file=<file> - configuration file to use. Defaults to
                        /etc/pam_pkcs11/card_eventmgr.conf
 
-Structure of configuration file is described bellow:
+Structure of configuration file is described below:
 
 card_eventmgr {
 

--- a/doc/README.mappers
+++ b/doc/README.mappers
@@ -28,8 +28,8 @@ An alternate way of working is by mean of not providing user name:
     - Map certificate into an user (*)
     - open session for deduced login
 
-Last way needs an aditional pam-mkhomedir.so PAM module, that can
-dinamically create an account.
+Last way needs an additional pam-mkhomedir.so PAM module, that can
+dynamically create an account.
 
 Operations (*) and (**) are the reason for cert-mappers to exist.
 
@@ -97,7 +97,7 @@ pw     - Compare CN against getpwent() "login" or "gecos" fields to match
         This means you can setup /etc/nsswitch.conf password entries
         to lookup in to /etc/passwd, or ldap/kerberos/NIS+/YP services
 
-ldap   - Uses an ldap server to retrieve user name. An aditional file tells
+ldap   - Uses an ldap server to retrieve user name. An additional file tells
          module the mapping between Cert fields and LDAP entries
 
         This mapper is still under development. Provided one just search
@@ -117,13 +117,13 @@ mail   - Try to extract an e-mail from the certificate. If found,
         tries to map the email field from the certificate to a user 
         (or alternate email).
 
-        if use_alias is not set, just use email addres from certificate
+        if use_alias is not set, just use email address from certificate
         to perform find/match.
 
         * When used as finder, just return email or mapped email/user
           (see above)
 		* When used as matcher, compare found email/user against
-		  provided by pam. Additionaly you can set "ignorecase" or
+		  provided by pam. Additionally you can set "ignorecase" or
 		  "ignoredomain" flags
 
         domain check (if set) is done by testing if provided email domain
@@ -165,13 +165,13 @@ edit skeleton sample files and follow instructions on how to compile
 and link
 
 Mapper.h provides default implementation for required some functions. 
-They should be overriden by user code, but can be used for testing purposes
+They should be overridden by user code, but can be used for testing purposes
 
 Wish list
 ---------
 
 - Implement PKINIT draft protocol for talking to a kerberos server
-- Use MS Universal Principal Name to autenticate against an MS Active
+- Use MS Universal Principal Name to authenticate against an MS Active
   directory server
 - Implement mail_aliases parsing for mail mapper module
 

--- a/doc/mappers_api.xml
+++ b/doc/mappers_api.xml
@@ -149,7 +149,7 @@ to ease mapper coding. You'll find:
 <sect1>
 <title>Configuration support</title>
 <para>
-Althought all mappers have default values, most of then have
+Although all mappers have default values, most of then have
 configuration options. The file <filename>/etc/pam_pkcs11/pam_pkcs11.conf</filename>
 stores them.
 </para>
@@ -157,16 +157,16 @@ stores them.
 
 </chapter>
 
-<chapter id="writting">
-	<title>Writting a mapper</title>
+<chapter id="writing">
+	<title>Writing a mapper</title>
 
 <sect1>
 <title>Before starting</title>
 <para>
 <itemizedlist>
-<listitem>Decide if the mapper will be statically or dinamically compiled
+<listitem>Decide if the mapper will be statically or dynamically compiled
 The first way is for simple, quick and easy mappers that doesn't need
-aditional/optional libraries, just inspect certificate contents.
+additional/optional libraries, just inspect certificate contents.
 
 The second way is for those mappers that need some optional libraries,
 such as ldap, kerberos, openssh or so</listitem>
@@ -210,7 +210,7 @@ When the mapper is used to map more than one field, you should add one entry
 for each mapped field. Each entry must have an unique mapper name, and (if the mapper is to be dynamically loaded) the same library name path
 </para>
 <para>
-See bellow on how to set up code to include multiple fields mappers to be
+See below on how to set up code to include multiple fields mappers to be
 statically compiled
 </para>
 </sect1>
@@ -286,7 +286,7 @@ FOO_EXTERN mapper_module * foo_mapper_module_init(scconf_block *blk,const char *
 <sect1>
 <title> Skeleton code for mapper C file.</title>
 <para>
-This is a sample skeleton file for single field mappers. It provides all the methods and data required by the API. Is up to you to include aditional functions as required.
+This is a sample skeleton file for single field mappers. It provides all the methods and data required by the API. Is up to you to include additional functions as required.
 </para>
 <para>
 They only need to export one symbol: the entry point of the init routine
@@ -453,7 +453,7 @@ mapper_module * foo_mapper_module_init(scconf_block *blk,const char *mapper_name
 </para>
 
 <para>
-See bellow on what's each function is intended to do, comodity macros, 
+See below on what's each function is intended to do, comodity macros, 
 and some examples on how to code them
 </para>
 </sect1>
@@ -577,7 +577,7 @@ struct mapper_listitem {
 The list of mappers to be loaded are declared by mean of <option>use_mappers</option> entry in <filename>/etc/pam_pkcs11/pam_pksc11.conf</filename> configuration file. Each declared mapper is loaded in turn. The first in the list will be the first one in the mapper chain
 </para>
 <para>
-On each mapper entry, <application>pam_pkcs11</application> search for the <option>module</option> keyword. If not found, or equals to "<option>internal</option>", the code assumes that reffers to an statically linked mapper, and search it in the list of mappers declared at <filename>src/mappers/mapperlist.c</filename>. Otherwise assume that we provide the full pathname to a dynamic library, and try to load by mean of <function>dlopen()</function> function
+On each mapper entry, <application>pam_pkcs11</application> search for the <option>module</option> keyword. If not found, or equals to "<option>internal</option>", the code assumes that refers to an statically linked mapper, and search it in the list of mappers declared at <filename>src/mappers/mapperlist.c</filename>. Otherwise assume that we provide the full pathname to a dynamic library, and try to load by mean of <function>dlopen()</function> function
 </para>
 <para>
 When module is found or loaded, the <function>module_load()</function> calls to the <function>mapper_module_init()</function> function, and if the result is not null assumes to be returned a pointer to the internal mapper entries table. These entries will be used to call finder, matcher, and deinit functions on the mapper
@@ -637,7 +637,7 @@ Many of the mapper functions are repetitive. Many others are nonsense in some ma
 </itemizedlist>
 </para>
 <para>
-The only usefull one is _DEFAULT_MAPPER_END, but the other ones are provided for compile work-in-progress mappers
+The only useful one is _DEFAULT_MAPPER_END, but the other ones are provided for compile work-in-progress mappers
 </para>
 <para>
 See the code, to provide you an idea of how to code real functions
@@ -647,7 +647,7 @@ See the code, to provide you an idea of how to code real functions
 <sect1>
 <title>Multifield mappers</title>
 <para>
-The sample code provided in first section can be used directly to create single field mappers. When writting multiple fields mappers ( a mapper, that can resolve two or more different certificate contents, ie CN and KPN ), a different approach is needed:
+The sample code provided in first section can be used directly to create single field mappers. When writing multiple fields mappers ( a mapper, that can resolve two or more different certificate contents, ie CN and KPN ), a different approach is needed:
 </para>
 <para>
 <itemizedlist>
@@ -677,7 +677,7 @@ Most of statically linked mappers share common configuration options:
 </itemizedlist>
 </para>
 <para>
-So if up to the system administrator, if agreed with default values, to ommit in the configuration file <filename>/etc/pam_pkcs11/pam_pkcs11.conf</filename> the mapper entry for this module. The module loader will look for proper mapper entry. If not found, assume that the module is static, and will try to load it and set up with default values. This behaviour is coded in the provided sample skeleton file for coding mappers
+So if up to the system administrator, if agreed with default values, to omit in the configuration file <filename>/etc/pam_pkcs11/pam_pkcs11.conf</filename> the mapper entry for this module. The module loader will look for proper mapper entry. If not found, assume that the module is static, and will try to load it and set up with default values. This behaviour is coded in the provided sample skeleton file for coding mappers
 </para>
 <para>
 Above note does not apply, of course, to dynamically loaded mappers, as they always need at least the "<option>module</option>" entry to be specified
@@ -716,7 +716,7 @@ Several functions and macros are provided to generate and display debug and erro
 The mapper API provides several functions to manage mapfiles. They are declared in <filename>src/mappers/mapper.h</filename>
 </para>
 <para>
-To use a mapfile, we must create a mapfile entry, then make sucessive calls to retrieve data, and finally destroy the structure. It works in a similar way as <function>setpwent(), getpwent() and endpwent()</function> functions works in walking throught a password file
+To use a mapfile, we must create a mapfile entry, then make successive calls to retrieve data, and finally destroy the structure. It works in a similar way as <function>setpwent(), getpwent() and endpwent()</function> functions works in walking through a password file
 </para>
 <para>
 The mapfile structure is defined as:
@@ -728,8 +728,8 @@ The mapfile structure is defined as:
 struct mapfile {
         const char *uri;/* URL of mapfile */
         char *buffer;   /* buffer to content of mapfile */
-        size_t length;  /* lenght of buffer */
-        char *pt;       /* pointer to last readed entry in buffer */
+        size_t length;  /* length of buffer */
+        char *pt;       /* pointer to last read entry in buffer */
         char *key;      /* key entry in current buffer */
         char *value;    /* value assigned to key */
 };
@@ -762,7 +762,7 @@ The returned "<option>key</option>" and "<option>value</option>" entries should 
 <application>PAM-PKCS#11</application> configuration files are based in the SCConf library of the <application>OpenSC</application> Project. See the file <filename>src/scconf/README.scconf</filename> for a detailed description of the <application>scconf</application>
 </para>
 <para>
-As a resume, bellow are shown the most relevants scconf API functions for the mapper programmer:
+As a resume, below are shown the most relevants scconf API functions for the mapper programmer:
 <itemizedlist>
 <listitem><function>const char *scconf_get_str(const scconf_block * block, const char *option, const char *default); </function> To retrieve the string value assigned to keyword <option>option</option> or return <option>default</option> if keyword not found</listitem>
 <listitem><function>int scconf_get_int(const scconf_block * block, const char *option, int default); </function> To retrieve the integer value assigned to keyword <option>option</option> or return <option>default</option> if keyword not found</listitem>
@@ -782,7 +782,7 @@ The user should not modify nor free() values returned from <function>scconf_get_
 <title> String tools API</title>
 
 <para>
-The <filename>string.h</filename> standard library is so powerfull. But lacks on some usefull routines. The file <filename>src/common/strings.c</filename> contains some of them, as declared at <filename>src/common/strings.h</filename>
+The <filename>string.h</filename> standard library is so powerful. But lacks on some useful routines. The file <filename>src/common/strings.c</filename> contains some of them, as declared at <filename>src/common/strings.h</filename>
 </para>
 <para>
 <itemizedlist>
@@ -794,7 +794,7 @@ The <filename>string.h</filename> standard library is so powerfull. But lacks on
 <listitem><function> unsigned char *hex2bin(const char *hexstr);</function> Convert a colon-separated hexadecimal string into a binary array</listitem>
 <listitem><function> unsigned char *hex2bin_static(const char *hexstr,unsigned char **res,int *size);</function> Same as above, but programmer supplies pre-allocated memory space for conversion</listitem>
 <listitem><function> char **split(const char *str,char sep, int nelems);</function> Splits provided string in an string array of nelems elements, using sep as character separator</listitem>
-<listitem><function> char **split_static(const char *str,char sep, int nelems,char *dst);</function> Same as above, but user provides pre-allocated buffer for storeing result</listitem>
+<listitem><function> char **split_static(const char *str,char sep, int nelems,char *dst);</function> Same as above, but user provides pre-allocated buffer for storing result</listitem>
 <listitem><function> char *trim(const char *str);</function> Return an string that has all superfluous spaces trimmed. Also converts any space char ( newline, tabs, etc ) in normal " " space character</listitem>
 </itemizedlist>
 </para>
@@ -802,7 +802,7 @@ The <filename>string.h</filename> standard library is so powerfull. But lacks on
 A note on <function>split(), and split_static()</function> functions. To free allocated resources, is enough to call <function>free()</function> on the first element of the array
 </para>
 <para>
-Note that <function>trim()</function> function behaviour is different from Java or PHP counterparts, as remove ALL extra spaces, not only at the begining and at the end of string
+Note that <function>trim()</function> function behaviour is different from Java or PHP counterparts, as remove ALL extra spaces, not only at the beginning and at the end of string
 </para>
 <para>
 See the code for further reference :-)
@@ -812,7 +812,7 @@ See the code for further reference :-)
 <sect1>
 <title> BASE64 Encoding functions </title>
 <para>
-In order to read/write public SSH keys, two funtions are provided to manage base64 encoding:
+In order to read/write public SSH keys, two functions are provided to manage base64 encoding:
 <itemizedlist>
 <listitem><function>int base64_encode(const unsigned char *in, size_t len, unsigned char *out, size_t outlen)</function> To encode a byte array into a base64 string</listitem>
 <listitem><function>int base64_decode(const char *in, unsigned char *out, size_t outlen)</function> To decode a base64 data into a byte array</listitem>
@@ -835,7 +835,7 @@ The basic library call is:
 </itemizedlist>
 </para>
 <para>
-This function takes an argument, the X509 certificate to be inspected, and a macro that shows the certificate content to be searched. Some contents needs an aditional third <option>algorithm</option> parameters. When not used should be set to NULL
+This function takes an argument, the X509 certificate to be inspected, and a macro that shows the certificate content to be searched. Some contents needs an additional third <option>algorithm</option> parameters. When not used should be set to NULL
 </para>
 <para>
 The mapper API defines following macros:
@@ -853,7 +853,7 @@ The mapper API defines following macros:
 </itemizedlist>
 </para>
 <para>
-Aditionally, when requesting <option>CERT_DIGEST</option> you must provide a valid digest algorithm:  "<option>null</option>", "<option>md2</option>", "<option>md4</option>", "<option>md5</option>", "<option>sha</option>", "<option>sha1</option>", "<option>dss</option>", "<option>dss1</option>" or "<option>ripemd160</option>"
+Additionally, when requesting <option>CERT_DIGEST</option> you must provide a valid digest algorithm:  "<option>null</option>", "<option>md2</option>", "<option>md4</option>", "<option>md5</option>", "<option>sha</option>", "<option>sha1</option>", "<option>dss</option>", "<option>dss1</option>" or "<option>ripemd160</option>"
 </para>
 <para>
 <function>cert_info()</function> returns an array of up to 15 string entries, corresponding to as many entry founds in the provided certificate. Last entry in the returned array is set to NULL;
@@ -881,10 +881,10 @@ There are two additional methods to check certificate/signatures:
 It's really recommended the study of provided mappers, and the comodity macros
 </para>
 <para>
-Before start writting a new mapper, perhaps you'd better to check if there are already one mapper that performs your desired map. For instance, pwent and generic mapper can use Naming Swictch Service (NSS) to lookup pasword entries, and NSS is capable of perform some LDAP or Kerberos authentication task
+Before start writing a new mapper, perhaps you'd better to check if there are already one mapper that performs your desired map. For instance, pwent and generic mapper can use Naming Swictch Service (NSS) to lookup password entries, and NSS is capable of perform some LDAP or Kerberos authentication task
 </para>
 <para>
-Don't hessitate in use of debugging functions. They are really usefull
+Don't hessitate in use of debugging functions. They are really useful
 </para>
 <para>
 It's recommended write mappers in a way that they could be statically or dynamically linked without code change, Doing so you'll make maintainer life easier :-)
@@ -894,7 +894,7 @@ Also, in order to ease debugging, single field mappers is preferred over multifi
 Avoid write access to any global variable from the mapper code. Use comodity functions
 </para>
 <para>
-Don't make assumptions on the code. Allways add checks. 
+Don't make assumptions on the code. Always add checks. 
 </para>
 <para>
 Use Universal Resource Locators -and the curl library- instead of hardcoded pathnames to specify files

--- a/doc/pam_pkcs11.xml
+++ b/doc/pam_pkcs11.xml
@@ -251,7 +251,7 @@ rpm -v -i /usr/src/redhat/RPMS/i386/pam_pkcs11-tools-X.Y-Z.i386.rpm</userinput>
 	allow an easy editing </listitem>
 
 	<listitem> Edit and configure <filename>/etc/pam.d/xxx</filename>
-	entries. See instructions bellow</listitem>
+	entries. See instructions below</listitem>
 
 	<listitem>Use <application>pkcs11_inspect</application> and
 	<application>pklogin_finder</application> provided tools to see if
@@ -468,7 +468,7 @@ Certificate2 data -> login3
 and returns on the first match.</para>
 
 <para>
-As you can see bellow, mapfile specification doesn't need to be
+As you can see below, mapfile specification doesn't need to be
 a regular file: you can retrieve data from any legal URL. Anyway, data 
 format must be preserved. See <xref linkend="mapfiles">mapfile</xref>
 for additional info.
@@ -1637,7 +1637,7 @@ Starting <application>pam-pkcs11-0.5.3</application> this module is now statical
 </para>
 <para>
 	Note: newer implementations of <function>getpwent()</function> libraries, use an
-	additional Name Service Swicth (NSS) infrastructure, that
+	additional Name Service Switch (NSS) infrastructure, that
 	allows administrators to specify how to obtain requested data.
 	This means you can setup <filename>/etc/nsswitch.conf</filename> password entries
 	to lookup in to <filename>/etc/passwd</filename>, or LDAP/Kerberos/NIS+/YP services
@@ -1701,7 +1701,7 @@ The following options are recognized by
 
 <varlistentry>
 <term><token>ldaphost</token></term>
-<listitem>The FQDN (hostname) oder IP-address of the ldap server.</listitem>
+<listitem>The FQDN (hostname) or IP-address of the ldap server.</listitem>
 </varlistentry>
 
 <varlistentry>
@@ -1804,7 +1804,7 @@ the attribute named by the <![CDATA[attribute]]> setting.
 
 <varlistentry>
 <term><token>filter</token></term>
-<listitem>LDAP filter string. You can use ist to restrict
+<listitem>LDAP filter string. You can use it to restrict
 the entries returned by the LDAP server, e.g. by checking
 other attributes of the user entry.
 %s is substituted by the user name.
@@ -1815,8 +1815,8 @@ LDAP entry is returned which has an objectClass
 "posixAccount" and the uid with the user name.
 
 <lineannotation>IMPORTANT NOTE:</lineannotation> The filter string
-must be choosen in such a way that only one entry for the user is 
-returned. If an user has more certifactes than these should be 
+must be chosen in such a way that only one entry for the user is 
+returned. If an user has more certificates than these should be 
 collected under the attribute.
 </listitem>
 </varlistentry>
@@ -2085,7 +2085,7 @@ Starting <application>pam-pkcs11-0.5.3</application> this module is now statical
 <para>
      Configuration file should provide the digest algorithm. Depending
 	 on <application>OpenSSL</application> configuration all of listed
-	 bellow may or not be present in your system.
+	 below may or not be present in your system.
 </para>
 <para>
 Configuration entry:

--- a/doc/pkcs11_eventmgr.1
+++ b/doc/pkcs11_eventmgr.1
@@ -17,7 +17,7 @@ Three events are supported: card insert, card removal and timeout on removed car
 Enable debugging output. Default is no debug
 .TP 
 \fB[no]daemon\fR
-Runs in background. If debug is unset, dettach also from tty. Default: no daemon
+Runs in background. If debug is unset, detach also from tty. Default: no daemon
 .TP 
 \fBpolling_time=<secs>\fR
 Set polling timeout in secs. Defaults to 1 sec
@@ -54,7 +54,7 @@ Some apps like [\fIxscreensaver\-command\fP] may fail due
 to external events ( eg: try to unlock an unlocked session ).
 In this case, command incorrectly returns error code.
 .br 
-User shoult take care on this circumstance
+User should take care on this circumstance
 .SH "AUTHORS"
 .LP 
 Juan Antonio Martinez <jonsito@teleline.es>

--- a/etc/pam_pkcs11.conf.example.in
+++ b/etc/pam_pkcs11.conf.example.in
@@ -151,7 +151,7 @@ pam_pkcs11 {
   # openssh - Search certificate public key in ${HOME}/.ssh/authorized_keys
   # mail    - Compare email fields from certificate
   # ms      - Use Microsoft Universal Principal Name extension
-  # krb     - Compare againts Kerberos Principal Name
+  # krb     - Compare against Kerberos Principal Name
   # cn      - Compare Common Name (CN)
   # uid     - Compare Unique Identifier
   # digest  - Certificate digest to login (mapfile based) mapper
@@ -216,7 +216,7 @@ pam_pkcs11 {
 	# module = @libdir@/pam_pkcs11/pwent_mapper.so;
   }
 
-  # Null ( no map ) mapper. when user as finder matchs to NULL or "nobody"
+  # Null ( no map ) mapper. when user as finder matches to NULL or "nobody"
   mapper null {
 	debug = false;
 	# module = @libdir@/pam_pkcs11/null_mapper.so;
@@ -237,7 +237,7 @@ pam_pkcs11 {
 	#   if no port is given in URI below
 	#   if empty, then 389 for TLS and 636 for SSL is used
 	ldapport = ;
-	# space separted list of LDAP URIs (URIs are used by given order)
+	# space separated list of LDAP URIs (URIs are used by given order)
 	URI = "";
 	# Scope of search: 0-2
 	#   Default is 1 = "one", meaning the set of records one
@@ -310,7 +310,7 @@ pam_pkcs11 {
 	domainname = "domain.com";
   }
 
-  # krb  - Compare againts Kerberos Principal Name
+  # krb  - Compare against Kerberos Principal Name
   mapper krb {
 	debug = false;
 	module = internal;

--- a/pam_pkcs11.spec
+++ b/pam_pkcs11.spec
@@ -28,7 +28,7 @@ Adittional included pam_pkcs11 related tools
 - pkcs11_eventmgr: Generate actions on card insert/removal/timeout events
 - pklogin_finder: Get the loginname that maps to a certificate
 - pkcs11_inspect: Inspect the contents of a certificate
-- make_hash_links: create hash link directories for storeing CA's and CRL's
+- make_hash_links: create hash link directories for storing CA's and CRL's
 
 %package pcsc
 Group:          System Environment/Utilities

--- a/src/common/cert_info.c
+++ b/src/common/cert_info.c
@@ -200,7 +200,7 @@ no_upn:
 * request info on certificate
 * @param x509 	Certificate to parse
 * @param type 	Information to retrieve
-* @param algorithm Digest algoritm to use
+* @param algorithm Digest algorithm to use
 * @return utf-8 string array with provided information
 */
 char **cert_info(X509 *x509, int type, ALGORITHM_TYPE algorithm ) {
@@ -898,7 +898,7 @@ static char **cert_info_serial_number(X509 *x509) {
 * request info on certificate
 * @param x509 	Certificate to parse
 * @param type 	Information to retrieve
-* @param algorithm Digest algoritm to use
+* @param algorithm Digest algorithm to use
 * @return utf-8 string array with provided information
 */
 char **cert_info(X509 *x509, int type, const char *algorithm ) {

--- a/src/common/cert_vfy.c
+++ b/src/common/cert_vfy.c
@@ -269,7 +269,7 @@ static int check_for_revocation(X509 * x509, X509_STORE_CTX * ctx, crl_policy_t 
     DBG("extracting crl distribution points");
     dist_points = X509_get_ext_d2i(x509, NID_crl_distribution_points, NULL, NULL);
     if (dist_points == NULL) {
-      /* if there is not crl distribution point in the certificate hava a look at the ca certificate */
+      /* if there is not crl distribution point in the certificate have a look at the ca certificate */
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
       rv = X509_STORE_get_by_subject(ctx, X509_LU_X509, X509_get_issuer_name(x509), &obj);
       if (rv > 0) {
@@ -441,7 +441,7 @@ add_store_error:
 }
 
 /*
-* @return -1 on error, 0 on verify failed, 1 on verify sucess
+* @return -1 on error, 0 on verify failed, 1 on verify success
 */
 int verify_certificate(X509 * x509, cert_policy *policy)
 {

--- a/src/common/cert_vfy.h
+++ b/src/common/cert_vfy.h
@@ -65,7 +65,7 @@ struct cert_policy_st {
 * Verify provided certificate, and if needed, CRL
 *@param x509 Certificate to check
 *@param policy CRL verify policy
-*@return 1 on cert vfy sucess, 0 on fail, -1 on process error
+*@return 1 on cert vfy success, 0 on fail, -1 on process error
 */
 CERTVFY_EXTERN int verify_certificate(X509 * x509, cert_policy *policy);
 
@@ -73,10 +73,10 @@ CERTVFY_EXTERN int verify_certificate(X509 * x509, cert_policy *policy);
 * Verify signature of provided data
 *@param x509 Certificate to be used
 *@param data Byte array of data to check
-*@param data_length Lenght of provided byte array
+*@param data_length Length of provided byte array
 *@param signature Byte array of signature to check
 *@param signature_length Length of signature byte array
-*@return 1 on signature vfy sucess, 0 on vfy fail, -1 on process error
+*@return 1 on signature vfy success, 0 on vfy fail, -1 on process error
 */
 CERTVFY_EXTERN int verify_signature(X509 * x509, unsigned char *data, int data_length, unsigned char **signature, unsigned long *signature_length);
 

--- a/src/common/pam-pkcs11-ossl-compat.h
+++ b/src/common/pam-pkcs11-ossl-compat.h
@@ -29,7 +29,7 @@ extern "C" {
 #include <openssl/opensslv.h>
 #include <openssl/opensslconf.h>
 /*
- * Provide backward compatability to older versions of OpenSSL
+ * Provide backward compatibility to older versions of OpenSSL
  * while using most of OpenSSL 1.1  API
  */
 
@@ -43,7 +43,7 @@ extern "C" {
  *
  * EVP_CIPHER_CTX_new	    does a EVP_CIPHER_CTX_init
  * EVP_CIPHER_CTX_free	    does a EVP_CIPHER_CTX_cleanup
- * EVP_CIPHER_CTX_cleanup   does equivelent of a EVP_CIPHER_CTX_init
+ * EVP_CIPHER_CTX_cleanup   does equivalent of a EVP_CIPHER_CTX_init
  * Use EVP_CIPHER_CTX_new, EVP_CIPHER_CTX_free, and  EVP_CIPHER_CTX_cleanup between operations
  */
 

--- a/src/common/pkcs11_lib.c
+++ b/src/common/pkcs11_lib.c
@@ -274,7 +274,7 @@ static SECMODModule *find_module_by_library(const char *pkcs11_module)
 
 /*
  * NSS allows you to load a specific module. If the user specified a module
- * to load, load it, otherwize select on of the standard modules from the
+ * to load, load it, otherwise select on of the standard modules from the
  * secmod.db list.
  */
 int load_pkcs11_module(const char *pkcs11_module, pkcs11_handle_t **hp)
@@ -308,7 +308,7 @@ int load_pkcs11_module(const char *pkcs11_module, pkcs11_handle_t **hp)
     return -1;
   }
   sprintf(moduleSpec,SPEC_TEMPLATE, pkcs11_module);
-  DBG2("loading Module explictly, moduleSpec=<%s> module=%s",
+  DBG2("loading Module explicitly, moduleSpec=<%s> module=%s",
                                                 moduleSpec, pkcs11_module);
   module = SECMOD_LoadUserModule(moduleSpec, NULL, 0);
   free(moduleSpec);
@@ -885,7 +885,7 @@ typedef struct tuple_str tuple_str;
 #include "sslerr.h"
 
 const tuple_str errStrings[] = {
-/* keep this list in asceding order of error numbers */
+/* keep this list in ascending order of error numbers */
 #include "SSLerrs.h"
 #include "SECerrs.h"
 #include "NSPRerrs.h"
@@ -1218,7 +1218,7 @@ int find_slot_by_number(pkcs11_handle_t *h, unsigned int slot_num, unsigned int 
 	for (slot_num = 0; slot_num < h->slot_count &&
 				!h->slots[slot_num].token_present; slot_num++);
    } else {
-	/* otherwize it's an index into the slot table  (it is *NOT* the slot
+	/* otherwise it's an index into the slot table  (it is *NOT* the slot
 	 * id!).... */
 	slot_num--;
    }

--- a/src/common/rsaref/pkcs11.h
+++ b/src/common/rsaref/pkcs11.h
@@ -94,7 +94,7 @@
 
 
 /* ==============================================================
- * Define structed vector of entry points.  A CK_FUNCTION_LIST
+ * Define structured vector of entry points.  A CK_FUNCTION_LIST
  * contains a CK_VERSION indicating a library's Cryptoki version
  * and then a whole slew of function pointers to the routines in
  * the library.  This type was declared, but not defined, in

--- a/src/common/strings.h
+++ b/src/common/strings.h
@@ -87,7 +87,7 @@ M_EXTERN unsigned char *hex2bin(const char *hexstr);
  * store result into a previously allocated space
  *@param hexstr String to be parsed
  *@param res Pointer to pre-allocated user space
- *@param size Pointer to store lenght of data parsed
+ *@param size Pointer to store length of data parsed
  *@return Pointer to resulting byte array, or null on parse error
  */
 M_EXTERN unsigned char *hex2bin_static(const char *hexstr,unsigned char **res,int *size);

--- a/src/common/uri.c
+++ b/src/common/uri.c
@@ -30,7 +30,7 @@ static const char *valid_urls[]=
 		{"file:///","http://","https://","ftp://","ldap://",NULL};
 /*
 comodity functions
-Analize provided pathname and check type
+Analyze provided pathname and check type
 Returns 1 on true, 0 on false, -1 on error
 */
 
@@ -481,7 +481,7 @@ static int get_http(uri_t *uri, unsigned char **data, size_t *length, int rec_le
       set_error("redirection uri is invalid that is not of the scheme http");
       return -1;
     }
-    /* downlaod recursively */
+    /* download recursively */
     rv = get_http(ruri, data, length, ++rec_level);
     free_uri(ruri);
     free(buf);

--- a/src/common/uri.h
+++ b/src/common/uri.h
@@ -51,7 +51,7 @@ URI_EXTERN int is_symlink(const char *path);
 *@param uri_str URL string where to retrieve data
 *@param data Pointer to a String buffer where data is retrieved
 *@param length Length of retrieved data
-*@return -1 on error, 0 on sucess
+*@return -1 on error, 0 on success
 */
 URI_EXTERN int get_from_uri(const char *uri_str, unsigned char **data, size_t *length);
 

--- a/src/mappers/ldap_mapper.c
+++ b/src/mappers/ldap_mapper.c
@@ -66,7 +66,7 @@ static const int LDAP_CONFIG_URI_MAX = 10;
  * TODO:
  * - Support for SASL-AUTH not included yet, I can't test it
  *
- * - ldap_unbind (*ld) crash if you connect to a SSL port but have set TLS intead SSL
+ * - ldap_unbind (*ld) crash if you connect to a SSL port but have set TLS instead SSL
  *   - no idea why!?
  *   - you got no error-massage from your application
  *   - believe skip ldap_unbind (*ld) for a bind handle isn't a good solution
@@ -278,7 +278,7 @@ static int do_ssl_options (LDAP *ldap_connection)
 		}
 	}
 
-	/* where is the requiered cert */
+	/* where is the required cert */
 	if (strncmp(tls_cert,"",1))
     {
 	    rc = ldap_set_option (NULL, LDAP_OPT_X_TLS_CERTFILE,
@@ -548,7 +548,7 @@ static int do_open (LDAP **ld, const char* uri, int defport, ldap_ssl_options_t 
 }
 
 /*
- * add singe URI to array of uris
+ * add single URI to array of uris
  */
 static int ldap_add_uri (char **uris, const char *a_uri, char **buffer, size_t *buflen)
 {
@@ -1073,7 +1073,7 @@ static int ldap_get_certificate(const char *login, X509 *x509) {
 		}
 
 		/* Only first entry is used. "filter" and "attribute"
-		 *  should be choosen, so that only one entry with
+		 *  should be chosen, so that only one entry with
 		 * one attribute is returned */
 		if ( NULL == (entry = ldap_first_entry(ldap_connection, res))){
 			DBG("ldap_first_entry() failed");

--- a/src/mappers/mail_mapper.c
+++ b/src/mappers/mail_mapper.c
@@ -44,7 +44,7 @@
 /* where to retrieve aliases file ( email -> login pairs ) */
 static const char *mapfile = "none";
 
-/* ignore upper/lowercase in email comparisions */
+/* ignore upper/lowercase in email comparisons */
 static int ignorecase = 1;
 
 /* also check the domain part on email field */
@@ -185,7 +185,7 @@ mapper_module * mail_mapper_module_init(scconf_block *blk,const char *mapper_nam
 	/* obtain and store hostname */
 	/* Note: in some systems without nis/yp, getdomainname() call
 	   returns NULL. So instead we use gethostname() an match
-	   mail domain by mean strstr() funtion */
+	   mail domain by mean strstr() function */
         if (!ignoredomain) {
 		hostname= calloc(256,sizeof(char));
 		if (!hostname) {

--- a/src/mappers/mapper.h
+++ b/src/mappers/mapper.h
@@ -65,9 +65,9 @@ struct mapfile {
 	const char *uri;
 	/** buffer to content of mapfile */
 	char *buffer;
-	/** lenght of buffer */
+	/** length of buffer */
 	size_t length;
-	/** pointer to last readed entry in buffer */
+	/** pointer to last read entry in buffer */
 	char *pt;
 	/** key entry in current buffer */
 	char *key;
@@ -110,7 +110,7 @@ MAPPER_EXTERN struct mapfile *set_mapent(const char *uri);
 /**
 * Retrieve next entry of given map file
 *@param mfile Map file entry pointer
-*@return 1 on sucess, 0 on no more entries, -1 on error
+*@return 1 on success, 0 on no more entries, -1 on error
 */
 MAPPER_EXTERN int    get_mapent(struct mapfile *mfile);
 
@@ -145,7 +145,7 @@ MAPPER_EXTERN int mapfile_match(const char *file,char *key,const char *value,int
 /**
 * find the user login that matches pw_name or pw_gecos with provided item
 *@param item Data to be searched from password database
-*@param ignorecase Flag to check upper/lowercase in string comparisions
+*@param ignorecase Flag to check upper/lowercase in string comparisons
 *@return userlogin if match found, else NULL
 */
 MAPPER_EXTERN char *search_pw_entry(const char *item, int ignorecase);
@@ -154,7 +154,7 @@ MAPPER_EXTERN char *search_pw_entry(const char *item, int ignorecase);
 * Test if provided item matches pw_name or pw_gecos of provided password structure
 *@param item String to be compared
 *@param pw password entry to search into
-*@param ignorecase Flag to check upper/lowercase in string comparisions
+*@param ignorecase Flag to check upper/lowercase in string comparisons
 *@return 1 on match, 0 on no match, -1 on error
 */
 MAPPER_EXTERN int compare_pw_entry(const char *item, struct passwd *pw,int ignorecase);

--- a/src/mappers/null_mapper.c
+++ b/src/mappers/null_mapper.c
@@ -36,7 +36,7 @@
 
 /*
 * A blind mapper: just read from config default value
-* and return it withouth further checking
+* and return it without further checking
 */
 
 static const char *default_user = "nobody";

--- a/src/pam_pkcs11/mapper_mgr.h
+++ b/src/pam_pkcs11/mapper_mgr.h
@@ -89,7 +89,7 @@ char * find_user(X509 *x509);
 int match_user(X509 *x509, const char *login);
 
 /*
-* This funcions goest throught the mapper list
+* This functions goes through the mapper list
 * and trying to get the certificate strings to be used on each
 * module to perform find/match functions.
 * No map / match are done: just print found strings on stdout.

--- a/src/pam_pkcs11/pam_pkcs11.c
+++ b/src/pam_pkcs11/pam_pkcs11.c
@@ -495,7 +495,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 	}
 
     /* call pkcs#11 login to ensure that the user is the real owner of the card
-     * we need to do thise before get_certificate_list because some tokens
+     * we need to do this before get_certificate_list because some tokens
      * can not read their certificates until the token is authenticated */
     rv = pkcs11_login(ph, password);
 

--- a/src/scconf/README.scconf
+++ b/src/scconf/README.scconf
@@ -18,7 +18,7 @@ It isn't
 It doesn't have
   - anything else but data. No locking, no threads etc.
 
-It has heirarchical data blocks, it has lists.
+It has hierarchical data blocks, it has lists.
 
 Similar, but different:
   - .ini files. scconf is block structured, has lists and arrays
@@ -132,9 +132,9 @@ const scconf_block *scconf_find_block(const scconf_context * config,
 	const scconf_block * block, const char *item_name);
 
 This finds a block in the given context. This function doesn't descend
-the heirarchy, it only finds blocks in the top level of either
+the hierarchy, it only finds blocks in the top level of either
 the context (the root block) or of the block given in the block
-paramter (if not NULL).
+parameter (if not NULL).
 
 The block pointer returned points to data held by the context, hence
 the const qualifier.

--- a/src/tools/card_eventmgr.c
+++ b/src/tools/card_eventmgr.c
@@ -70,7 +70,7 @@ char AraKiri = FALSE;
 
 static void thats_all_folks(void) {
     int rv;
-    DBG("Exitting");
+    DBG("Exiting");
     /* We try to leave things as clean as possible */
     rv = SCardReleaseContext(hContext);
     if (rv != SCARD_S_SUCCESS) {
@@ -139,7 +139,7 @@ static int execute_event (const char *action) {
 	while (actionlist) {
 		int res;
 		char *action_cmd= actionlist->data;
-		DBG1("Executiong action: '%s'",action_cmd);
+		DBG1("Executing action: '%s'",action_cmd);
 		/*
 		there are some security issues on using system() in
 		setuid/setgid programs. so we will use an alternate function

--- a/src/tools/pkcs11_eventmgr.c
+++ b/src/tools/pkcs11_eventmgr.c
@@ -96,7 +96,7 @@ struct pkcs11_handle_str
 static void thats_all_folks(void)
 {
 	int rv;
-	DBG("Exitting");
+	DBG("Exiting");
 #ifdef HAVE_NSS
 	if (module)
 	{
@@ -203,7 +203,7 @@ static int execute_event(const char *action)
 	{
 		int res;
 		char *action_cmd = actionlist->data;
-		DBG1("Executiong action: '%s'", action_cmd);
+		DBG1("Executing action: '%s'", action_cmd);
 		/*
 		   there are some security issues on using system() in
 		   setuid/setgid programs. so we will use an alternate function
@@ -484,7 +484,7 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 		sprintf(moduleSpec, SPEC_TEMPLATE, pkcs11_module);
-		DBG2("loading Module explictly, moduleSpec=<%s> module=%s\n",
+		DBG2("loading Module explicitly, moduleSpec=<%s> module=%s\n",
 			moduleSpec, pkcs11_module);
 		module = SECMOD_LoadUserModule(moduleSpec, NULL, 0);
 		free(moduleSpec);


### PR DESCRIPTION
* Fix typos found by [codespell](https://github.com/codespell-project/codespell)
* Add to CI with a list of words to ignore and skipping third-party files in `src/common`