### PR TITLE
Making changes to pkcs11_make_hash_link to support whitespaces in file names

### DIFF
--- a/tools/pkcs11_make_hash_link
+++ b/tools/pkcs11_make_hash_link
@@ -50,6 +50,11 @@ then
 	exit -1
 fi
 # process all files
+
+#change IFS to be able to loop through files with whitespaces in file names
+OLD_IFS=$IFS
+IFS=$'\n'
+
 for file in *; do
   hash=`$OPENSSL x509 -inform pem -in $file -noout -hash 2> /dev/null`
   if [ ! -z "$hash" ]; then
@@ -85,5 +90,8 @@ for file in *; do
   # nothing can be done with the file
   echo "we got a problem with: $file"
 done
+
+#restore previous IFS value
+IFS=$OLD_IFS
 
 exit 0

--- a/tools/pkcs11_make_hash_link
+++ b/tools/pkcs11_make_hash_link
@@ -51,47 +51,44 @@ then
 fi
 # process all files
 
-#change IFS to be able to loop through files with whitespaces in file names
-OLD_IFS=$IFS
-IFS=$'\n'
+(
+  IFS=$'\n'
 
-for file in *; do
-  hash=`$OPENSSL x509 -inform pem -in $file -noout -hash 2> /dev/null`
-  if [ ! -z "$hash" ]; then
-    is_ca=`$OPENSSL x509 -inform pem -in $file -noout -text | grep 'CA:TRUE'`
-    if [ ! -z "$is_ca" ]; then
-      hash=$hash.
-      mk_link
+  for file in *; do
+    hash=`$OPENSSL x509 -inform pem -in $file -noout -hash 2> /dev/null`
+    if [ ! -z "$hash" ]; then
+      is_ca=`$OPENSSL x509 -inform pem -in $file -noout -text | grep 'CA:TRUE'`
+      if [ ! -z "$is_ca" ]; then
+        hash=$hash.
+        mk_link
+      fi
+      continue
     fi
-    continue
-  fi
-  hash=`$OPENSSL x509 -inform der -in $file -noout -hash 2> /dev/null`
-  if [ ! -z "$hash" ]; then
-    is_ca=`$OPENSSL x509 -inform der -in $file -noout -text | grep 'CA:TRUE'`
-    if [ ! -z "$is_ca" ]; then
-      hash=$hash.
-      mk_link
+    hash=`$OPENSSL x509 -inform der -in $file -noout -hash 2> /dev/null`
+    if [ ! -z "$hash" ]; then
+      is_ca=`$OPENSSL x509 -inform der -in $file -noout -text | grep 'CA:TRUE'`
+      if [ ! -z "$is_ca" ]; then
+        hash=$hash.
+        mk_link
+      fi
+      continue
     fi
-    continue
-  fi
-  hash=`$OPENSSL crl -inform pem -in $file -noout -hash 2> /dev/null`
-  if [ ! -z "$hash" ]; then
-    hash=$hash.r
-    mk_link
-    continue
-  fi
-  hash=`$OPENSSL crl -inform der -in $file -noout -hash 2> /dev/null`
-  if [ ! -z "$hash" ]; then
-    hash=$hash.r
-    mk_link
-    continue
-  fi
+    hash=`$OPENSSL crl -inform pem -in $file -noout -hash 2> /dev/null`
+    if [ ! -z "$hash" ]; then
+      hash=$hash.r
+      mk_link
+      continue
+    fi
+    hash=`$OPENSSL crl -inform der -in $file -noout -hash 2> /dev/null`
+    if [ ! -z "$hash" ]; then
+      hash=$hash.r
+      mk_link
+      continue
+    fi
 
-  # nothing can be done with the file
-  echo "we got a problem with: $file"
-done
-
-#restore previous IFS value
-IFS=$OLD_IFS
+    # nothing can be done with the file
+    echo "we got a problem with: $file"
+  done
+)
 
 exit 0


### PR DESCRIPTION
In brief: substitute IFS value with '\n' to make bash ignore whitespaces as separators, then restore to previous value. This will allow pkcs11_make_hash_link to generate links for certificate files with whitespaces in file names.