### PR TITLE
Capitalize message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AM_MAINTAINER_MODE
 AM_GNU_GETTEXT([external])
 
 dnl Add the languages which your application supports here.
-ALL_LINGUAS="de fr it nl pl pt_BR ru tr"
+ALL_LINGUAS="de fr it nl pl pt_BR ru tr zh_CN"
 
 # Checks for programs.
 AC_PROG_CC

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2011-03-20 17:04+0100\n"
 "Last-Translator: Dominik Fischer <dom_fischer@web.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,144 +16,167 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
+#: src/pam_pkcs11/pam_pkcs11.c:340
 #, fuzzy
-msgid "Smartcard authentication starts"
-msgstr "Smartcardauthentifizierung startet"
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Bitte %s einstecken oder Benutzername eingeben."
-
-#: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr "Fehler 2302: PKCS11-Modul konnte nicht geladen werden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
+#: src/pam_pkcs11/pam_pkcs11.c:354
+#, fuzzy
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr "Fehler 2304: PKCS11-Modul konnte nicht initialisiert werden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr "Fehler 2306: Es wurde keine Smartcard gefunden."
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Bitte stecken Sie Ihre Smart Card mit der Bezeichnung \"%.32s\" ein"
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Bitte stecken Sie Ihre Smart Card ein."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+#, fuzzy
+msgid "Error 2308: No smart card found."
 msgstr "Fehler 2308: Es wurde keine Smartcard gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr "Fehler 2310: Es wurde keine Smartcard gefunden."
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Fehler 2308: Es wurde keine Smartcard gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "%s gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+#, fuzzy
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr "Fehler 2312: PKCS11-Session konnte nicht geoeffnet werden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+#, fuzzy
+msgid "Error 2314: Slot login failed."
 msgstr "Fehler 2314: Slot Login fehlgeschlagen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Willkommen %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+#, fuzzy
+msgid "Error 2316: Password could not be read."
 msgstr "Fehler 2316: Passwort konnte nicht eingelesen werden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+#, fuzzy
+msgid "Error 2318: Empty smart card PIN not allowed."
 msgstr "Fehler 2318: Smartcard PIN darf nicht leer sein."
 
-#: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
 msgstr "Bitte geben Sie Ihre %s PIN auf dem Pinpad ein"
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:506
+#, fuzzy
+msgid "Error 2320: Wrong smart card PIN."
 msgstr "Fehler 2320: Die eingegebene Smartcard PIN ist falsch."
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:519
+#, fuzzy
+msgid "Error 2322: No certificate found."
 msgstr "Fehler 2322: Es wurde kein Zertifikat gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:534
+#, fuzzy
+msgid "Verifying certificate..."
 msgstr "Zertifikat wird geprueft."
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+#, fuzzy
+msgid "Error 2324: Certificate has expired."
 msgstr "Fehler 2324: Zertifikat abgelaufen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+#, fuzzy
+msgid "Error 2326: Certificate not yet valid."
 msgstr "Fehler 2326: Zertifikat noch nicht gueltig."
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+#, fuzzy
+msgid "Error 2328: Certificate signature invalid."
 msgstr "Fehler 2328: Zertifikatsunterschrift ungueltig."
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+#, fuzzy
+msgid "Error 2330: Certificate invalid."
 msgstr "Fehler 2330: Ungueltiges Zertifikat gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+#, fuzzy
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr "Fehler 2332: PAM Usereintrag konnte nicht gesetzt werden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+#, fuzzy
+msgid "Error 2334: No matching user."
 msgstr "Fehler 2334: Pruefung des Usereintrags fehlgeschlagen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+#, fuzzy
+msgid "Error 2336: No matching certificate found."
 msgstr "Fehler 2336: Kein passendes Zertifikat gefunden."
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:640
+#, fuzzy
+msgid "Checking signature..."
 msgstr "Signieren wird geprueft."
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+#, fuzzy
+msgid "Error 2338: Getting random value failed."
 msgstr "Fehler 2338: Holen der Zufallszahl zum Signieren fehlgeschlagen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+#, fuzzy
+msgid "Error 2340: Signing failed."
 msgstr "Fehler 2340: Signieren fehlgeschlagen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+#, fuzzy
+msgid "Error 2342: Verifying signature failed."
 msgstr "Fehler 2342: Verifizierung der Signatur fehlgeschlagen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:808
+#, fuzzy
+msgid "Smart card authentication cancelled."
+msgstr "Smartcardauthentifizierung startet"
+
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Das Kennwort Ihrer Smart Card kann nicht geändert werden."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Smart Card"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Bitte %s einstecken oder Benutzername eingeben."
+
+#~ msgid "Error 2306: No suitable token available"
+#~ msgstr "Fehler 2306: Es wurde keine Smartcard gefunden."
+
+#~ msgid "Error 2310: No smartcard found"
+#~ msgstr "Fehler 2310: Es wurde keine Smartcard gefunden."
 
 #~ msgid "Error 2344: Closing PKCS#11 session failed"
 #~ msgstr "Fehler 2344: PKCS11 Session konnte nicht geschlossen werden."

--- a/po/fr.po
+++ b/po/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_pkcs11 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2007-05-22 10:27+0200\n"
 "Last-Translator: Ludovic Rousseau <ludovic.rousseau@free.fr>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -15,143 +15,139 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Veuillez insérer votre %s ou entrer votre login."
 
 #: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Veuillez insérer la carte à puce appelée \"%.32s\"."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Veuillez insérer votre carte à puce."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr ""
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Carte à puce"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "%s trouvé(e)."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Bienvenue %.32s !"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "PIN du/de la %s : "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr "Entrez le PIN %s sur le pinpad"
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
-msgstr "Entrez le PIN %s sur le pinpad"
-
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+msgid "Verifying certificate..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+msgid "Checking signature..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:808
+msgid "Smart card authentication cancelled."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Ne peut pas changer le mot de passe de la carte à puce."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Carte à puce"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Veuillez insérer votre %s ou entrer votre login."
 
 #~ msgid "Found the %s."
 #~ msgstr "%s trouvé(e)."

--- a/po/it.po
+++ b/po/it.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_pkcs11 0.6.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2014-03-05 16:32+0100\n"
 "Last-Translator: Maxxer <maxxer@yetopen.it>\n"
 "Language-Team: Italian\n"
@@ -16,140 +16,164 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
-msgstr "Inizio autenticazione con smartcard"
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Inserire il proprio %s o il nome utente."
-
-#: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+#, fuzzy
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr "Errore 2302: impossibile caricare il modulo PKCS#11"
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
+#: src/pam_pkcs11/pam_pkcs11.c:354
+#, fuzzy
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr "Errore 2304: impossibile inizializzare il modulo PKCS#11"
 
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr "Errore 2306: nesun token disponibile"
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Inserire la smartcard con nome \"%.32s\"."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Inserire la smartcard."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+#, fuzzy
+msgid "Error 2308: No smart card found."
 msgstr "Errore 2308: nessuna smartcard trovata"
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr "Errore 2310: Nessuna smartcard trovata"
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Errore 2308: nessuna smartcard trovata"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "Trovato %s."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+#, fuzzy
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr "Errore 2312: errore nell'apertura della sessione PKCS#11"
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+#, fuzzy
+msgid "Error 2314: Slot login failed."
 msgstr "Errore 2314: login con slot fallito"
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Benvenuto %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "PIN %s: "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+#, fuzzy
+msgid "Error 2316: Password could not be read."
 msgstr "Errore 2316: impossibile leggere la password"
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+#, fuzzy
+msgid "Error 2318: Empty smart card PIN not allowed."
 msgstr "Error 2318: PIN vuoto non consentito per la smartcard."
 
-#: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
 msgstr "Inserire il PIN %s sul tastierino"
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:506
+#, fuzzy
+msgid "Error 2320: Wrong smart card PIN."
 msgstr "Errore 2320: PIN errato"
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:519
+#, fuzzy
+msgid "Error 2322: No certificate found."
 msgstr "Errore 2322: nessun certificato trovato"
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:534
+#, fuzzy
+msgid "Verifying certificate..."
 msgstr "verifica certificato"
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+#, fuzzy
+msgid "Error 2324: Certificate has expired."
 msgstr "Errore 2324: certificato scaduto"
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+#, fuzzy
+msgid "Error 2326: Certificate not yet valid."
 msgstr "Errore 2326: certificato non ancora valido"
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+#, fuzzy
+msgid "Error 2328: Certificate signature invalid."
 msgstr "Errore 2328: firma certificato non valida"
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+#, fuzzy
+msgid "Error 2330: Certificate invalid."
 msgstr "Errore 2330: certfificato non valido"
 
-#: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+#, fuzzy
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr "Errore 2332: errore impostazione utente in PAM"
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+#, fuzzy
+msgid "Error 2334: No matching user."
 msgstr "Errore 2334: nessun utente corrispondente trovato"
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+#, fuzzy
+msgid "Error 2336: No matching certificate found."
 msgstr "Errore 2336: nessun certificato corrispondente trovato"
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:640
+#, fuzzy
+msgid "Checking signature..."
 msgstr "Verifica firma"
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+#, fuzzy
+msgid "Error 2338: Getting random value failed."
 msgstr "Errore 2338: errore reperimento valore casuale"
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+#, fuzzy
+msgid "Error 2340: Signing failed."
 msgstr "Errore 2340: firma fallita"
 
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+#, fuzzy
+msgid "Error 2342: Verifying signature failed."
 msgstr "Errore 2342: verifica firma fallita"
 
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:808
+#, fuzzy
+msgid "Smart card authentication cancelled."
+msgstr "Inizio autenticazione con smartcard"
+
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Impossibile modificare la password sulla smartcard."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Smartcard"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Inserire il proprio %s o il nome utente."
+
+#~ msgid "Error 2306: No suitable token available"
+#~ msgstr "Errore 2306: nesun token disponibile"
+
+#~ msgid "Error 2310: No smartcard found"
+#~ msgstr "Errore 2310: Nessuna smartcard trovata"

--- a/po/nl.po
+++ b/po/nl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_pkcs11 0.5.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2010-05-30 09:00+0200\n"
 "Last-Translator: Guy Zelck <gzelck@gmail.com>\n"
 "Language-Team: Dutch <nl@li.org>\n"
@@ -15,143 +15,139 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Gelieve je %s aan te brengen of je gebruikersnaam in te geven."
 
 #: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Gelieve je smartcard genaamd \"%.32s\" aan te brengen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Gelieve je smartcard aan te brengen."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr ""
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Smartcard"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Welkom %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "PIN van %s : "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+msgid "Verifying certificate..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+msgid "Checking signature..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:808
+msgid "Smart card authentication cancelled."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Kan het paswoord op je smartcard niet wijzigen."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Smartcard"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Gelieve je %s aan te brengen of je gebruikersnaam in te geven."
 
 #~ msgid "Found the %s."
 #~ msgstr "%s gevonden."

--- a/po/pam_pkcs11.pot
+++ b/po/pam_pkcs11.pot
@@ -5,9 +5,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pam_pkcs11 0.6.8\n"
+"Project-Id-Version: pam_pkcs11 0.6.12\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-11 16:54+0300\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,141 +16,128 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:1187
-msgid "Smartcard authentication cancelled"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:413
+msgid "No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+msgid "Verifying certificate..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+msgid "Checking signature..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:808
+msgid "Smart card authentication cancelled."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_pkcs11 0.6.7\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2011-08-11 16:22+0200\n"
 "Last-Translator: Jakub Bogusz <qboosh@pld-linux.org>\n"
 "Language-Team: Polish <translation-team-pl@lists.sourceforge.net>\n"
@@ -15,144 +15,167 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
+#: src/pam_pkcs11/pam_pkcs11.c:340
 #, fuzzy
-msgid "Smartcard authentication starts"
-msgstr "Rozpoczęcie uwierzytelniania kartą procesorową"
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Proszę włożyć token (%s) lub wpisać nazwę użytkownika."
-
-#: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr "Błąd 2302: wczytanie modułu PKCS#11 nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
+#: src/pam_pkcs11/pam_pkcs11.c:354
+#, fuzzy
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr "Błąd 2304: nie udało się zainicjować modułu PKCS#11"
 
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr "Błąd 2306: Brak odpowiedniego tokenu"
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Proszę włożyć własną kartę procesorową o nazwie \"%.32s\"."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Proszę włożyć własną kartę procesorową."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+#, fuzzy
+msgid "Error 2308: No smart card found."
 msgstr "Błąd 2308: Nie znaleziono karty procesorowej"
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr "Błąd 2310: Nie znaleziono karty procesorowej"
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Błąd 2308: Nie znaleziono karty procesorowej"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "Znaleziono token: %s."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+#, fuzzy
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr "Błąd 2312: nie udało się otworzyć sesji PKCS#11"
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+#, fuzzy
+msgid "Error 2314: Slot login failed."
 msgstr "Błąd 2314: Logowanie przez slot nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Witaj %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "%s - PIN: "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+#, fuzzy
+msgid "Error 2316: Password could not be read."
 msgstr "Błąd 2316: nie udało się odczytać hasła"
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+#, fuzzy
+msgid "Error 2318: Empty smart card PIN not allowed."
 msgstr "Błąd 2318: Pusty PIN karty procesorowej nie jest dozwolony."
 
-#: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
 msgstr "Proszę wprowadzić PIN tokenu (%s) na klawiaturze czytnika"
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:506
+#, fuzzy
+msgid "Error 2320: Wrong smart card PIN."
 msgstr "Błąd 2320: Błędny PIN karty procesorowej"
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:519
+#, fuzzy
+msgid "Error 2322: No certificate found."
 msgstr "Błąd 2322: Nie znaleziono certyfikatu"
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:534
+#, fuzzy
+msgid "Verifying certificate..."
 msgstr "weryfikacja certyfikatu"
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+#, fuzzy
+msgid "Error 2324: Certificate has expired."
 msgstr "Błąd 2324: Certyfikat wygasł"
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+#, fuzzy
+msgid "Error 2326: Certificate not yet valid."
 msgstr "Błąd 2326: Certyfikat jeszcze nie jest ważny"
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+#, fuzzy
+msgid "Error 2328: Certificate signature invalid."
 msgstr "Błąd 2328: Błędny podpis certyfikatu"
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+#, fuzzy
+msgid "Error 2330: Certificate invalid."
 msgstr "Błąd 2330: Błędny certyfikat"
 
-#: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+#, fuzzy
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr "Błąd 2332: ustawienie wpisu użytkownika PAM nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+#, fuzzy
+msgid "Error 2334: No matching user."
 msgstr "Błąd 2334: Brak pasującego użytkownika"
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+#, fuzzy
+msgid "Error 2336: No matching certificate found."
 msgstr "Błąd 2336: Nie znaleziono pasującego certyfikatu"
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:640
+#, fuzzy
+msgid "Checking signature..."
 msgstr "Sprawdzanie podpisu"
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+#, fuzzy
+msgid "Error 2338: Getting random value failed."
 msgstr "Błąd 2338: Pobranie wartości losowej nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+#, fuzzy
+msgid "Error 2340: Signing failed."
 msgstr "Błąd 2340: Podpisanie nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+#, fuzzy
+msgid "Error 2342: Verifying signature failed."
 msgstr "Błąd 2342: Sprawdzenie podpisu nie powiodło się"
 
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:808
+#, fuzzy
+msgid "Smart card authentication cancelled."
+msgstr "Rozpoczęcie uwierzytelniania kartą procesorową"
+
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Nie można zmienić hasła na tej karcie procesorowej."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Karta procesorowa"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Proszę włożyć token (%s) lub wpisać nazwę użytkownika."
+
+#~ msgid "Error 2306: No suitable token available"
+#~ msgstr "Błąd 2306: Brak odpowiedniego tokenu"
+
+#~ msgid "Error 2310: No smartcard found"
+#~ msgstr "Błąd 2310: Nie znaleziono karty procesorowej"
 
 #~ msgid "Error 2344: Closing PKCS#11 session failed"
 #~ msgstr "Błąd 2344: Błąd zamykania sesji PKCS#11"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2015-08-26 10:42-0300\n"
 "Last-Translator: Alexandre Souza Aguiar <alexandre.aguiar@serpro.gov.br>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,143 +16,167 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
-msgstr "Autenticação com smartcard iniciou"
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Favor inserir seu %s ou entre com um nome de usuário."
-
-#: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+#, fuzzy
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr "Erro 2302: Modulo PKCS#11 falhou carregando"
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
+#: src/pam_pkcs11/pam_pkcs11.c:354
+#, fuzzy
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr "Error 2304: Modulo PKCS#11 não pôde ser inicializado"
 
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr "Error 2306: Sem token disponíveis"
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Favor inserir seu smartcard chamado \"%.32s\"."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Favor inserir seu smartcard."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+#, fuzzy
+msgid "Error 2308: No smart card found."
 msgstr "Error 2308: Não foram achados smartcards"
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr "Error 2310: Não foram achados smartcards"
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Error 2308: Não foram achados smartcards"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "%s achado."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+#, fuzzy
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr "Error 2312: abertura da sessão PKCS#11 falhou"
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+#, fuzzy
+msgid "Error 2314: Slot login failed."
 msgstr "Error 2314: Slot de login falhou"
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Bem vindo %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "%s PIN: "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+#, fuzzy
+msgid "Error 2316: Password could not be read."
 msgstr "Error 2316: senha não pôde ser lida"
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+#, fuzzy
+msgid "Error 2318: Empty smart card PIN not allowed."
 msgstr "Error 2318: Senha de PIN vazia não permitida."
 
-#: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
 msgstr "Digite seu PIN %s no pinpad"
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:506
+#, fuzzy
+msgid "Error 2320: Wrong smart card PIN."
 msgstr "Error 2320: PIN do smartcard errado"
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:519
+#, fuzzy
+msgid "Error 2322: No certificate found."
 msgstr "Error 2322: Não foram encontrados certificados"
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:534
+#, fuzzy
+msgid "Verifying certificate..."
 msgstr "verificando certificado"
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+#, fuzzy
+msgid "Error 2324: Certificate has expired."
 msgstr "Error 2324: Certificado expirou"
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+#, fuzzy
+msgid "Error 2326: Certificate not yet valid."
 msgstr "Error 2326: Certificado ainda não é válido"
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+#, fuzzy
+msgid "Error 2328: Certificate signature invalid."
 msgstr "Error 2328: Assinatura do certificado inválida"
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+#, fuzzy
+msgid "Error 2330: Certificate invalid."
 msgstr "Error 2330: Certificado inválido"
 
-#: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+#, fuzzy
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr "Error 2332: falha ao setando PAM userentry"
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+#, fuzzy
+msgid "Error 2334: No matching user."
 msgstr "Error 2334: Nenhum usuário correspondente"
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+#, fuzzy
+msgid "Error 2336: No matching certificate found."
 msgstr "Error 2336: Nenhum certificado correspondente encontrado"
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:640
+#, fuzzy
+msgid "Checking signature..."
 msgstr "Verificando a assinatura"
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+#, fuzzy
+msgid "Error 2338: Getting random value failed."
 msgstr "Error 2338: Falha ao obter valor aleatório"
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+#, fuzzy
+msgid "Error 2340: Signing failed."
 msgstr "Error 2340: Assinatura falhou"
 
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+#, fuzzy
+msgid "Error 2342: Verifying signature failed."
 msgstr "Error 2342: Falha ao verificar assinatura"
 
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:808
+#, fuzzy
+msgid "Smart card authentication cancelled."
+msgstr "Autenticação com smartcard iniciou"
+
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Não foi possível alterar a senha no seu smart card."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Smartcard"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Favor inserir seu %s ou entre com um nome de usuário."
+
+#~ msgid "Error 2306: No suitable token available"
+#~ msgstr "Error 2306: Sem token disponíveis"
+
+#~ msgid "Error 2310: No smartcard found"
+#~ msgstr "Error 2310: Não foram achados smartcards"
 
 #~ msgid "Found the %s."
 #~ msgstr "%s encontrado."

--- a/po/remove-potcdate.sed
+++ b/po/remove-potcdate.sed
@@ -1,0 +1,11 @@
+/^"POT-Creation-Date: .*"$/{
+x
+s/P/P/
+ta
+g
+d
+bb
+:a
+x
+:b
+}

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2019-01-11 16:55+0300\n"
 "Last-Translator: Paul Wolneykien <manowar@altlinux.org>\n"
 "Language-Team: Russian\n"
@@ -17,141 +17,130 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:1187
-msgid "Smartcard authentication cancelled"
-msgstr "Аутентификация по токену отменена"
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, fuzzy, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Пожалуйста, вставьте смарткарту или введите имя пользователя."
 
 #: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Пожалуйста, вставьте смарткарту, которая называется \"%.32s\"."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Пожалуйста, вставьте смарткарту."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr ""
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Смарткарта вставлена. "
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Добро пожаловать %.32s!"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
+msgid "Verifying certificate..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+msgid "Checking signature..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
-msgstr ""
+#: src/pam_pkcs11/pam_pkcs11.c:808
+#, fuzzy
+msgid "Smart card authentication cancelled."
+msgstr "Аутентификация по токену отменена"
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Не могу поменять пароль смарткарты."
 
@@ -159,6 +148,10 @@ msgstr "Не могу поменять пароль смарткарты."
 #, fuzzy
 msgid "Smart card"
 msgstr "Смарткарта вставлена. "
+
+#, fuzzy, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Пожалуйста, вставьте смарткарту или введите имя пользователя."
 
 #~ msgid "Smart card password: "
 #~ msgstr "Пароль смарткарты: "

--- a/po/tr.po
+++ b/po/tr.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pam_pkcs11 0.6.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-23 16:55+0200\n"
+"POT-Creation-Date: 2022-12-01 15:13+0800\n"
 "PO-Revision-Date: 2011-07-05 11:17:+0300\n"
 "Last-Translator: Ozan Çağlayan <ozan@pardus.org.tr>\n"
 "Language-Team: Turkish <tr@li.org>\n"
@@ -14,140 +14,136 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/pam_pkcs11/pam_pkcs11.c:235
-msgid "Smartcard authentication starts"
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
 msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:324 src/pam_pkcs11/pam_pkcs11.c:433
-#, c-format
-msgid "Please insert your %s or enter your username."
-msgstr "Lütfen size ait bir %s yerleştirin veya kullanıcı adınızı girin."
 
 #: src/pam_pkcs11/pam_pkcs11.c:354
-msgid "Error 2302: PKCS#11 module failed loading"
+msgid "Error 2304: PKCS#11 module could not be initialized."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:368
-msgid "Error 2304: PKCS#11 module could not be initialized"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:387
-msgid "Error 2306: No suitable token available"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:401
+#: src/pam_pkcs11/pam_pkcs11.c:385
 #, c-format
 msgid "Please insert your smart card called \"%.32s\"."
 msgstr "Lütfen \"%.32s\" isimli akıllı kartı yerleştirin."
 
-#: src/pam_pkcs11/pam_pkcs11.c:405
+#: src/pam_pkcs11/pam_pkcs11.c:389
 msgid "Please insert your smart card."
 msgstr "Lütfen akıllı kartı yerleştirin."
 
-#: src/pam_pkcs11/pam_pkcs11.c:422
-msgid "Error 2308: No smartcard found"
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:449
-msgid "Error 2310: No smartcard found"
-msgstr ""
+#: src/pam_pkcs11/pam_pkcs11.c:413
+#, fuzzy
+msgid "No smart card found."
+msgstr "Akıllı kart"
 
-#: src/pam_pkcs11/pam_pkcs11.c:459
+#: src/pam_pkcs11/pam_pkcs11.c:420
 #, c-format
 msgid "%s found."
 msgstr "%s bulundu."
 
-#: src/pam_pkcs11/pam_pkcs11.c:466
-msgid "Error 2312: open PKCS#11 session failed"
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:478
-msgid "Error 2314: Slot login failed"
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:486
+#: src/pam_pkcs11/pam_pkcs11.c:447
 #, c-format
 msgid "Welcome %.32s!"
 msgstr "Hoş geldiniz %.32s"
 
-#: src/pam_pkcs11/pam_pkcs11.c:494
+#: src/pam_pkcs11/pam_pkcs11.c:455
 #, c-format
 msgid "%s PIN: "
 msgstr "%s PIN: "
 
-#: src/pam_pkcs11/pam_pkcs11.c:505
-msgid "Error 2316: password could not be read"
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:525
-msgid "Error 2318: Empty smartcard PIN not allowed."
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, fuzzy, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr "PIN klavyesini kullanarak %s PIN kodunu giriniz."
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:534
-#, c-format
-msgid "Enter your %s PIN on the pinpad"
-msgstr "PIN klavyesini kullanarak %s PIN kodunu giriniz."
-
-#: src/pam_pkcs11/pam_pkcs11.c:553
-msgid "Error 2320: Wrong smartcard PIN"
+msgid "Verifying certificate..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:565
-msgid "Error 2322: No certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:580
-msgid "verifying certificate"
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:593
-msgid "Error 2324: Certificate has expired"
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:597
-msgid "Error 2326: Certificate not yet valid"
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:601
-msgid "Error 2328: Certificate signature invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:605
-msgid "Error 2330: Certificate invalid"
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
+msgstr ""
+
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
 msgstr ""
 
 #: src/pam_pkcs11/pam_pkcs11.c:640
-msgid "Error 2332: setting PAM userentry failed"
+msgid "Checking signature..."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:656
-msgid "Error 2334: No matching user"
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:677
-msgid "Error 2336: No matching certificate found"
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:686
-msgid "Checking signature"
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:706
-msgid "Error 2338: Getting random value failed"
+#: src/pam_pkcs11/pam_pkcs11.c:808
+msgid "Smart card authentication cancelled."
 msgstr ""
 
-#: src/pam_pkcs11/pam_pkcs11.c:720
-msgid "Error 2340: Signing failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:739
-msgid "Error 2342: Verifying signature failed"
-msgstr ""
-
-#: src/pam_pkcs11/pam_pkcs11.c:886
+#: src/pam_pkcs11/pam_pkcs11.c:854
 msgid "Cannot change the password on your smart card."
 msgstr "Akıllı kart parolası değiştirilemiyor."
 
 #: src/pam_pkcs11/pam_config.c:65
 msgid "Smart card"
 msgstr "Akıllı kart"
+
+#, c-format
+#~ msgid "Please insert your %s or enter your username."
+#~ msgstr "Lütfen size ait bir %s yerleştirin veya kullanıcı adınızı girin."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,145 @@
+# Chinese translations for pam_pkcs11 package.
+# This file is put in the public domain.
+# Alynx Zhou <alynx.zhou@gmail.com>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: pam_pkcs11 0.6.12\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-12-01 14:31+0800\n"
+"PO-Revision-Date: 2022-12-01 14:53+0800\n"
+"Last-Translator: Alynx Zhou <alynx.zhou@gmail.com>\n"
+"Language-Team: Chinese (simplified) <i18n-zh@googlegroups.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/pam_pkcs11/pam_pkcs11.c:340
+msgid "Error 2302: PKCS#11 module failed loading."
+msgstr "错误 2302：PKCS#11 模块加载失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:354
+msgid "Error 2304: PKCS#11 module could not be initialized."
+msgstr "错误 2304：PKCS#11 模块无法初始化。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:385
+#, c-format
+msgid "Please insert your smart card called \"%.32s\"."
+msgstr "请插入名为 \"%.32s\" 的智能卡。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:389
+msgid "Please insert your smart card."
+msgstr "请插入您的智能卡。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:408
+msgid "Error 2308: No smart card found."
+msgstr "错误 2308：未检测到智能卡。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:413
+msgid "No smart card found."
+msgstr "未检测到智能卡。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:420
+#, c-format
+msgid "%s found."
+msgstr "检测到 %s。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:428
+msgid "Error 2312: Open PKCS#11 session failed."
+msgstr "错误 2312：开启 PKCS#11 会话失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:440
+msgid "Error 2314: Slot login failed."
+msgstr "错误 2314：卡槽登录失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:447
+#, c-format
+msgid "Welcome %.32s!"
+msgstr "欢迎 %.32s！"
+
+#: src/pam_pkcs11/pam_pkcs11.c:455
+#, c-format
+msgid "%s PIN: "
+msgstr "%s PIN: "
+
+#: src/pam_pkcs11/pam_pkcs11.c:466
+msgid "Error 2316: Password could not be read."
+msgstr "错误 2316：无法读取密码。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:482
+msgid "Error 2318: Empty smart card PIN not allowed."
+msgstr "错误 2318：不允许使用空白的智能卡 PIN。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:492
+#, c-format
+msgid "Enter your %s PIN on the pinpad."
+msgstr "请在密码键盘上输入您的 %s PIN。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:506
+msgid "Error 2320: Wrong smart card PIN."
+msgstr "错误 2320：智能卡 PIN 不正确。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:519
+msgid "Error 2322: No certificate found."
+msgstr "错误 2322：未检测到证书。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:534
+msgid "Verifying certificate..."
+msgstr "正在验证证书……"
+
+#: src/pam_pkcs11/pam_pkcs11.c:547
+msgid "Error 2324: Certificate has expired."
+msgstr "错误 2324：证书已过期。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:551
+msgid "Error 2326: Certificate not yet valid."
+msgstr "错误 2326：证书还未生效。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:555
+msgid "Error 2328: Certificate signature invalid."
+msgstr "错误 2328：证书签名无效。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:559
+msgid "Error 2330: Certificate invalid."
+msgstr "错误 2330：证书无效。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:594
+msgid "Error 2332: Setting PAM user entry failed."
+msgstr "错误 2332：设置 PAM 用户条目失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:610
+msgid "Error 2334: No matching user."
+msgstr "错误 2334：没有匹配到用户。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:631
+msgid "Error 2336: No matching certificate found."
+msgstr "错误 2336：没有匹配到证书。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:640
+msgid "Checking signature..."
+msgstr "正在检查签名……"
+
+#: src/pam_pkcs11/pam_pkcs11.c:660
+msgid "Error 2338: Getting random value failed."
+msgstr "错误 2338：获取随机值失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:674
+msgid "Error 2340: Signing failed."
+msgstr "错误 2340：签名失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:691
+msgid "Error 2342: Verifying signature failed."
+msgstr "错误 2342：验证签名失败。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:808
+msgid "Smart card authentication cancelled."
+msgstr "智能卡认证取消。"
+
+#: src/pam_pkcs11/pam_pkcs11.c:854
+msgid "Cannot change the password on your smart card."
+msgstr "无法修改智能卡上的密码。"
+
+#: src/pam_pkcs11/pam_config.c:65
+msgid "Smart card"
+msgstr "智能卡"

--- a/src/pam_pkcs11/pam_pkcs11.c
+++ b/src/pam_pkcs11/pam_pkcs11.c
@@ -337,7 +337,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     if (!configuration->quiet) {
 		pam_syslog(pamh, LOG_ERR, "load_pkcs11_module() failed loading %s: %s",
 			configuration->pkcs11_modulepath, get_error());
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2302: PKCS#11 module failed loading"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2302: PKCS#11 module failed loading."));
 		sleep(configuration->err_display_time);
 	}
     return pkcs11_pam_fail;
@@ -351,7 +351,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     ERR1("init_pkcs11_module() failed: %s", get_error());
     if (!configuration->quiet) {
 		pam_syslog(pamh, LOG_ERR, "init_pkcs11_module() failed: %s", get_error());
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2304: PKCS#11 module could not be initialized"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2304: PKCS#11 module could not be initialized."));
 		sleep(configuration->err_display_time);
 	}
     return pkcs11_pam_fail;
@@ -405,12 +405,12 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       if (pkcs11_pam_fail != PAM_IGNORE) {
           if (!configuration->quiet) {
               pam_prompt(pamh, PAM_ERROR_MSG,
-                         NULL, _("Error 2308: No smartcard found"));
+                         NULL, _("Error 2308: No smart card found."));
               sleep(configuration->err_display_time);
           }
       } else {
           pam_prompt(pamh, PAM_TEXT_INFO,
-                     NULL, _("No smartcard found"));
+                     NULL, _("No smart card found."));
           goto exit_ignore;
       }
       return pkcs11_pam_fail;
@@ -425,7 +425,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     ERR1("open_pkcs11_session() failed: %s", get_error());
     if (!configuration->quiet) {
 		pam_syslog(pamh, LOG_ERR, "open_pkcs11_session() failed: %s", get_error());
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2312: open PKCS#11 session failed"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2312: Open PKCS#11 session failed."));
 		sleep(configuration->err_display_time);
 	}
     release_pkcs11_module(ph);
@@ -437,7 +437,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     ERR1("get_slot_login_required() failed: %s", get_error());
     if (!configuration->quiet) {
 		pam_syslog(pamh, LOG_ERR, "get_slot_login_required() failed: %s", get_error());
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2314: Slot login failed"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2314: Slot login failed."));
 		sleep(configuration->err_display_time);
 	}
     goto auth_failed;
@@ -463,7 +463,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 		}
 		if (rv != PAM_SUCCESS) {
 			if (!configuration->quiet) {
-				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2316: password could not be read"));
+				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2316: Password could not be read."));
 				sleep(configuration->err_display_time);
 			}
 			pam_syslog(pamh, LOG_ERR,
@@ -479,7 +479,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 			pam_syslog(pamh, LOG_ERR,
 					"password length is zero but the 'nullok' argument was not defined.");
 			if (!configuration->quiet) {
-				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2318: Empty smartcard PIN not allowed."));
+				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2318: Empty smart card PIN not allowed."));
 				sleep(configuration->err_display_time);
 			}
 			pkcs11_pam_fail = PAM_AUTH_ERR;
@@ -489,7 +489,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 	else
 	{
 		pam_prompt(pamh, PAM_TEXT_INFO, NULL,
-			_("Enter your %s PIN on the pinpad"), _(configuration->token_type));
+			_("Enter your %s PIN on the pinpad."), _(configuration->token_type));
 		/* use pin pad */
 		password = NULL;
 	}
@@ -503,7 +503,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       ERR1("open_pkcs11_login() failed: %s", get_error());
 		if (!configuration->quiet) {
 			pam_syslog(pamh, LOG_ERR, "open_pkcs11_login() failed: %s", get_error());
-			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2320: Wrong smartcard PIN"));
+			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2320: Wrong smart card PIN."));
 			sleep(configuration->err_display_time);
 		}
       pkcs11_pam_fail = PAM_AUTH_ERR;
@@ -516,7 +516,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     ERR1("get_certificate_list() failed: %s", get_error());
     if (!configuration->quiet) {
 		pam_syslog(pamh, LOG_ERR, "get_certificate_list() failed: %s", get_error());
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2322: No certificate found"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2322: No certificate found."));
 		sleep(configuration->err_display_time);
 	}
     goto auth_failed;
@@ -531,7 +531,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
     if (!x509 ) continue; /* sanity check */
     DBG1("verifying the certificate #%d", i + 1);
 	if (!configuration->quiet) {
-		pam_prompt(pamh, PAM_TEXT_INFO, NULL, _("verifying certificate"));
+		pam_prompt(pamh, PAM_TEXT_INFO, NULL, _("Verifying certificate..."));
 	}
 
       /* verify certificate (date, signature, CRL, ...) */
@@ -544,19 +544,19 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 			switch (rv) {
 				case -2: // X509_V_ERR_CERT_HAS_EXPIRED:
 					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2324: Certificate has expired"));
+						_("Error 2324: Certificate has expired."));
 					break;
 				case -3: // X509_V_ERR_CERT_NOT_YET_VALID:
 					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2326: Certificate not yet valid"));
+						_("Error 2326: Certificate not yet valid."));
 					break;
 				case -4: // X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
 					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2328: Certificate signature invalid"));
+						_("Error 2328: Certificate signature invalid."));
 					break;
 				default:
 					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2330: Certificate invalid"));
+						_("Error 2330: Certificate invalid."));
 					break;
 			}
 			sleep(configuration->err_display_time);
@@ -591,7 +591,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
             if (!configuration->quiet) {
 				pam_syslog(pamh, LOG_ERR,
                        "pam_set_item() failed %s", pam_strerror(pamh, rv));
-				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2332: setting PAM userentry failed"));
+				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2332: Setting PAM user entry failed."));
 				sleep(configuration->err_display_time);
 			}
 	    goto auth_failed;
@@ -607,7 +607,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
           ERR1("match_user() failed: %s", get_error());
 			if (!configuration->quiet) {
 				pam_syslog(pamh, LOG_ERR, "match_user() failed: %s", get_error());
-				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2334: No matching user"));
+				pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2334: No matching user."));
 				sleep(configuration->err_display_time);
 			}
 	  goto auth_failed;
@@ -628,7 +628,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 		if (!configuration->quiet) {
 			pam_syslog(pamh, LOG_ERR,
 				"no valid certificate which meets all requirements found");
-		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2336: No matching certificate found"));
+		pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2336: No matching certificate found."));
 		sleep(configuration->err_display_time);
 	}
     goto auth_failed;
@@ -637,7 +637,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
 
   /* if signature check is enforced, generate random data, sign and verify */
   if (configuration->policy.signature_policy) {
-		pam_prompt(pamh, PAM_TEXT_INFO, NULL, _("Checking signature"));
+		pam_prompt(pamh, PAM_TEXT_INFO, NULL, _("Checking signature..."));
 
 
 #ifdef notdef
@@ -657,7 +657,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       ERR1("get_random_value() failed: %s", get_error());
 		if (!configuration->quiet){
 			pam_syslog(pamh, LOG_ERR, "get_random_value() failed: %s", get_error());
-			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2338: Getting random value failed"));
+			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2338: Getting random value failed."));
 			sleep(configuration->err_display_time);
 		}
       goto auth_failed;
@@ -671,7 +671,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       ERR1("sign_value() failed: %s", get_error());
 		if (!configuration->quiet) {
 			pam_syslog(pamh, LOG_ERR, "sign_value() failed: %s", get_error());
-			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2340: Signing failed"));
+			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2340: Signing failed."));
 			sleep(configuration->err_display_time);
 		}
       goto auth_failed;
@@ -688,7 +688,7 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       ERR1("verify_signature() failed: %s", get_error());
 		if (!configuration->quiet) {
 			pam_syslog(pamh, LOG_ERR, "verify_signature() failed: %s", get_error());
-			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2342: Verifying signature failed"));
+			pam_prompt(pamh, PAM_ERROR_MSG , NULL, _("Error 2342: Verifying signature failed."));
 			sleep(configuration->err_display_time);
 		}
       pkcs11_pam_fail = PAM_AUTH_ERR;
@@ -805,7 +805,7 @@ auth_failed:
 
  exit_ignore:
 	pam_prompt( pamh, PAM_TEXT_INFO, NULL,
-				_("Smartcard authentication cancelled") );
+				_("Smart card authentication cancelled.") );
 	return PAM_IGNORE;
 }
 


### PR DESCRIPTION
This PR did 3 things:

1. Unified all messages that will be shown to user via `pam_prompt`, before this commit some of them are capitalized but some are not, some have periods but some are not.
2. Updated PO files by running `make -C po update-po`.
3. Added Simplified Chinese translation.

If there are something wrong please tell me, I'll correct them soon, thanks!