### PR TITLE
Better parse error

### DIFF
--- a/src/pam_pkcs11/pam_config.c
+++ b/src/pam_pkcs11/pam_config.c
@@ -111,7 +111,7 @@ static void parse_config_file(void) {
 	}
 	ctx = configuration.ctx;
 	if ( scconf_parse(ctx) <=0 ) {
-           DBG1("Error parsing file %s",configuration.config_file);
+           DBG2("Error parsing file %s. Parse error: %s",configuration.config_file,ctx->errmsg);
 	   return;
 	}
 	/* now parse options */


### PR DESCRIPTION
I spent almost a full day trying to figure out why pam_pkcs11 kept spitting out "Error setting configuration parameters". Thankfully, I found this source code, downloaded it, made this edit and compiled it. It turned out the default filename was incorrect (file missing). I was following the Ubuntu 18.04 [guide](https://ubuntu.com/server/docs/smart-card-authentication). I've also alerted in the guide that the default filename is incorrect.

It would be tremendously helpful to include the specific parse error.