### PR TITLE
fix: resolve double free crash during CRL validation

### DIFF
--- a/src/common/cert_vfy.c
+++ b/src/common/cert_vfy.c
@@ -251,16 +251,15 @@ static int check_for_revocation(X509 * x509, X509_STORE_CTX * ctx, crl_policy_t 
   } else if (policy == CRLP_OFFLINE) {
     /* OFFLINE */
     DBG("looking for an dedicated local crl");
+    /* crl pointer is extracted from obj; obj is freed at the unified exit: label below */
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     rv = X509_STORE_get_by_subject(ctx, X509_LU_CRL, X509_get_issuer_name(x509), &obj);
     if (rv > 0) {
       crl = X509_OBJECT_get0_X509_CRL((&obj));
-      X509_OBJECT_free_contents(&obj);
 #else
     rv = X509_STORE_get_by_subject(ctx, X509_LU_CRL, X509_get_issuer_name(x509), obj);
     if (rv > 0) {
       crl = X509_OBJECT_get0_X509_CRL(obj);
-      X509_OBJECT_free(obj);
 #endif
     } else {
       set_error("no dedicated crl available");
@@ -273,16 +272,15 @@ static int check_for_revocation(X509 * x509, X509_STORE_CTX * ctx, crl_policy_t 
     dist_points = X509_get_ext_d2i(x509, NID_crl_distribution_points, NULL, NULL);
     if (dist_points == NULL) {
       /* if there is not crl distribution point in the certificate have a look at the ca certificate */
+      /* x509_ca pointer is extracted from obj; obj is freed at the unified exit: label below */
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
       rv = X509_STORE_get_by_subject(ctx, X509_LU_X509, X509_get_issuer_name(x509), &obj);
       if (rv > 0) {
         x509_ca = X509_OBJECT_get0_X509((&obj));
-        X509_OBJECT_free_contents(&obj);
 #else
       rv = X509_STORE_get_by_subject(ctx, X509_LU_X509, X509_get_issuer_name(x509), obj);
       if (rv > 0) {
         x509_ca = X509_OBJECT_get0_X509(obj);
-        X509_OBJECT_free(obj);
 #endif
       } else {
         set_error("no dedicated ca certificate available");


### PR DESCRIPTION
The previous implementation prematurely called "X509_OBJECT_free_contents(&obj)" (or "X509_OBJECT_free(obj)") inside the conditional branches after extracting the pointers.

However, there is already a unified cleanup routine for this object at the "exit"  label. This duplicate cleanup logic caused the same object to be freed twice, immediately triggering a "double free detected in tcache 2" abort in glibc.

This patch removes the redundant early deallocation, relying entirely on the unified "exit:" phase to properly manage the object's lifecycle.