### PR TITLE
chore: don't report per-certificate verify_certificate() failures

### DIFF
--- a/src/pam_pkcs11/pam_pkcs11.c
+++ b/src/pam_pkcs11/pam_pkcs11.c
@@ -543,33 +543,14 @@ PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, cons
       /* verify certificate (date, signature, CRL, ...) */
       rv = verify_certificate(x509,&configuration->policy);
       if (rv < 0) {
-        ERR1("verify_certificate() failed: %s", get_error());
-        if (!configuration->quiet) {
-          pam_syslog(pamh, LOG_ERR,
-                   "verify_certificate() failed: %s", get_error());
-			switch (rv) {
-				case -2: // X509_V_ERR_CERT_HAS_EXPIRED:
-					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2324: Certificate has expired."));
-					break;
-				case -3: // X509_V_ERR_CERT_NOT_YET_VALID:
-					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2326: Certificate not yet valid."));
-					break;
-				case -4: // X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
-					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2328: Certificate signature invalid."));
-					break;
-				default:
-					pam_prompt(pamh, PAM_ERROR_MSG , NULL,
-						_("Error 2330: Certificate invalid."));
-					break;
-			}
-			sleep(configuration->err_display_time);
-		}
+        /* This certificate does not meet the policy requirements, but other
+         * slots/certificates (e.g. on a multi-slot token) may still yield a
+         * valid one, so only log at debug level and keep trying. An error is
+         * only reported to the user if no certificate at all is found. */
+        DBG1("verify_certificate() failed: %s", get_error());
         continue; /* try next certificate */
       } else if (rv != 1) {
-        ERR1("verify_certificate() failed: %s", get_error());
+        DBG1("verify_certificate() failed: %s", get_error());
         continue; /* try next certificate */
       }
 


### PR DESCRIPTION
Hello,

On multi-slot tokens (e.g. YubiKey), some slots/certificates may fail verify_certificate() while others are still valid. 

Log these failures at debug level instead of surfacing a user-facing error/prompt for each one. only report an error when no certificate at all is found.